### PR TITLE
FIX: update getting started page to include a route

### DIFF
--- a/src/docs/documentation/general/getting-started.mdx
+++ b/src/docs/documentation/general/getting-started.mdx
@@ -53,11 +53,12 @@ format because of the flexibility of writing JSX inside markdown files.
 
 > Note that you **don't need to follow any strict file architecture**. You can just create your `.mdx` files **anywhere in your project**.
 
-So, let's create our first `.mdx` and give it a name:
+So, let's create our first `.mdx` and give it a name and a route:
 
 ```markdown
 ---
 name: Hello world
+route: /
 ---
 
 # Hello world


### PR DESCRIPTION
When working through the Getting Started example, I had to specify `route: /` in the mdx frontmatter. Without it I was presented with the Gatsby 404 page when running the dev server.

docz version: `2.0.0-rc.38`