### PR TITLE
docs: change `built-ins-components` => `built-in-components`

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -24,7 +24,7 @@ export default {
         'Introduction',
         'Getting started',
         'Writing MDX',
-        'Built-ins components',
+        'Built-in components',
         'Document settings',
         'Deploying your docs',
       ],

--- a/src/docs/documentation/general/built-in-components.mdx
+++ b/src/docs/documentation/general/built-in-components.mdx
@@ -1,11 +1,11 @@
 ---
-name: Built-ins components
-route: /docs/built-ins-components
+name: Built-in components
+route: /docs/built-in-components
 parent: Documentation
 menu: General
 ---
 
-# Built-ins components
+# Built-in components
 
 Docz has built-in components that help you to document your things. Using the power of components and AST to parse and generate data for them, we can do a lot of things,
 like render your components, create tables with contents, custom getters by traversing your file, etc. The sky is the limit here!

--- a/src/docs/documentation/general/writing-mdx.mdx
+++ b/src/docs/documentation/general/writing-mdx.mdx
@@ -35,7 +35,7 @@ And, if you really have a `Button` component to import, you'll see something lik
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/Fgbg4F)
 
-With MDX you can mix _React Components_ or _html-elements_ with regular markdown allowing you to either document your own components _or_ creating helper components that makes documentation easier. **Docz** comes with some prebuilt helper components which will help you document components faster, these are covered in [**Built-in components**](/docs/built-ins-components).
+With MDX you can mix _React Components_ or _html-elements_ with regular markdown allowing you to either document your own components _or_ creating helper components that makes documentation easier. **Docz** comes with some prebuilt helper components which will help you document components faster, these are covered in [**Built-in components**](/docs/built-in-components).
 
 > ### Note
 >


### PR DESCRIPTION
docs: correct inconsistent usage of built-ins-components vs built-in-components in favor of later to fix link from `usage-with-typescript.md`.

note: this will break external linking to https://www.docz.site/docs/built-ins-components but seems necessary since it should be https://www.docz.site/docs/built-in-components