### PR TITLE
docs: use react-helmet-async instead of react-helmet

### DIFF
--- a/src/docs/documentation/customizing/add-favicon-and-metadata.mdx
+++ b/src/docs/documentation/customizing/add-favicon-and-metadata.mdx
@@ -7,7 +7,9 @@ menu: Customizing
 
 # Add favicon and metadata
 
-Adding metadata to your site is done by configuring Gatsby in combination with [`react-helmet`](https://github.com/nfl/react-helmet) [**source @ gatsby**](https://www.gatsbyjs.org/docs/add-page-metadata/).
+Adding metadata to your site is done by configuring Gatsby in combination with [`react-helmet-async`](https://github.com/staylor/react-helmet-async) [**source @ gatsby**](https://www.gatsbyjs.org/docs/add-page-metadata/). 
+
+> Please note that we're referencing `react-helmet-async`, and not `react-helmet`. This is because of [this issue](https://github.com/nfl/react-helmet/issues/426). `react-helmet-async` is an API-compatible fork, so you shouldn't need to do anything except importing from a different package.
 
 
 ### Shadowing the Wrapper-component
@@ -18,7 +20,7 @@ The metadata is set up in a file called `wrapper.js` which lives in docz theme p
 2. Paste the following content and edit it to your liking
 ```js
 import * as React from 'react'
-import { Helmet } from 'react-helmet'
+import { Helmet } from 'react-helmet-async'
 
 const Wrapper = ({ children }) => <React.Fragment>
 	<Helmet>


### PR DESCRIPTION
This commit updates the documentation to recommend `react-helmet-async`
instead of `react-helmet`, as well as a note about why.

It looks like this:

![screenshot of the new UI](https://user-images.githubusercontent.com/1307267/68148030-8883c080-ff3b-11e9-83e5-2e4e84e6ba5f.png)

Should be merged after this: https://github.com/doczjs/docz/pull/1223