### PR TITLE
docs: update theme-ui initialColorMode key

### DIFF
--- a/src/docs/documentation/customizing/gatsby-theme.mdx
+++ b/src/docs/documentation/customizing/gatsby-theme.mdx
@@ -86,7 +86,7 @@ To set the dark version as default, just set your `doczrc.js` like that:
 // doczrc.js
 export default {
   themeConfig: {
-    mode: 'dark',
+    initialColorMode: 'dark',
   },
 }
 ```


### PR DESCRIPTION
I believe the correct key here is `initialColorMode` per https://theme-ui.com/theme-spec/#color-modes