### PR TITLE
docs(gatsby-theme): set correct import of base theme

### DIFF
--- a/src/docs/documentation/customizing/gatsby-theme.mdx
+++ b/src/docs/documentation/customizing/gatsby-theme.mdx
@@ -201,7 +201,7 @@ export default {
 Or, to create your own theme, just create this file in the root of your project: `src/gatsby-theme-docz/theme/index.js`.
 
 ```js
-import baseTheme from 'gatsby-theme-docz/src/theme'
+import baseTheme from 'gatsby-theme-docz/src/theme/index'
 import { merge } from 'lodash/fp'
 
 export default merge(baseTheme, {


### PR DESCRIPTION
If you skip the index, it just imports undefined. That way we ensure the correct theme/file is imported.