### PR TITLE
Fix filename in code comment

### DIFF
--- a/src/docs/documentation/references/migration-guide.mdx
+++ b/src/docs/documentation/references/migration-guide.mdx
@@ -95,7 +95,7 @@ Check [here](https://www.docz.site/docs/creating-themes) for more information ab
 The same thing happened here for the oldest `wrapper` property. Now you can wrap your entire application by just creating a file called `src/gatsby-theme-docz/wrapper.js`
 
 ```js
-// src/gatsby-theme-docz/index.js
+// src/gatsby-theme-docz/wrapper.js
 import React from 'react'
 
 export default ({ children }) => (


### PR DESCRIPTION
Incorrect filename listed in the code comment. Using `index.js` replaces the entire theme.