### PR TITLE
docs: fix broken link to the base theme object

### DIFF
--- a/src/docs/documentation/customizing/gatsby-theme.mdx
+++ b/src/docs/documentation/customizing/gatsby-theme.mdx
@@ -181,7 +181,7 @@ Docz's code uses [Theme-UI](https://theme-ui.com/) as the default theme system.
 
 You can modify the default theme and create your own style by combining these modifications with component shadowing.
 
-Check our [base theme object](https://github.com/pedronauck/docz/blob/feat/gatsby/core/gatsby-theme-docz/src/theme/index.js) to see the properties.
+Check our [base theme object](https://github.com/doczjs/docz/blob/master/core/gatsby-theme-docz/src/theme/index.js) to see the properties.
 
 To create your own theme definition use the `doczrc.js` and set your properties in the `themeConfig` like that:
 


### PR DESCRIPTION
This link (`https://github.com/doczjs/docz/blob/feat/gatsby/core/gatsby-theme-docz/src/theme/index.js`) currently leads to a 404:

![image](https://user-images.githubusercontent.com/5247455/72113066-39b82580-32f4-11ea-956c-caf8ec1ca190.png)

It appears that the base config object now lives at: https://github.com/doczjs/docz/blob/master/core/gatsby-theme-docz/src/theme/index.js